### PR TITLE
Enable calendar popup for date selection

### DIFF
--- a/src/rosbag_editor.ui
+++ b/src/rosbag_editor.ui
@@ -336,6 +336,9 @@
             <property name="displayFormat">
              <string>[yy/M/d] H:mm:ss.z</string>
             </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
@@ -351,6 +354,9 @@
             </property>
             <property name="displayFormat">
              <string>[yy/M/d] H:mm:ss.z</string>
+            </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Fixes #6 

Now when the right arrow is clicked a calendar opens which allows to select any available date:
![Screenshot_20200305_104421](https://user-images.githubusercontent.com/5566160/75968979-8a03cc00-5ece-11ea-8a95-50fc223c9340.png)

https://doc.qt.io/qt-5/qdatetimeedit.html#calendarPopup-prop
