### PR TITLE
Fix crash because of extra row

### DIFF
--- a/src/rosbag_editor.cpp
+++ b/src/rosbag_editor.cpp
@@ -86,10 +86,6 @@ void RosbagEditor::on_pushButtonLoad_pressed()
     rosbag::View bag_view ( _bag );
     auto connections = bag_view.getConnections();
 
-    ui->tableWidgetInput->setRowCount(connections.size());
-    ui->tableWidgetInput->setColumnCount(2);
-    ui->tableWidgetInput->setEnabled(true);
-
     QDateTime datetime_begin = QDateTime::fromMSecsSinceEpoch( bag_view.getBeginTime().toSec()*1000 );
     ui->dateTimeInputBegin->setDateTime(datetime_begin);
 
@@ -102,9 +98,13 @@ void RosbagEditor::on_pushButtonLoad_pressed()
     for(std::size_t i = 0; i < connections.size(); i++ )
     {
       const rosbag::ConnectionInfo* connection = connections[i];
-     connections_ordered.insert( std::make_pair(QString::fromStdString(connection->topic),
-                                                QString::fromStdString(connection->datatype) ) );
+      connections_ordered.insert( std::make_pair(QString::fromStdString(connection->topic),
+                                                 QString::fromStdString(connection->datatype) ) );
     }
+
+    ui->tableWidgetInput->setRowCount(connections_ordered.size());
+    ui->tableWidgetInput->setColumnCount(2);
+    ui->tableWidgetInput->setEnabled(true);
 
     int row = 0;
     for(const auto conn: connections_ordered )


### PR DESCRIPTION
Fixes #8 

`connections` vector contains a duplicate: `/rosout` `rosgraph_msgs/Log` when its created.
The `connections` are ordered in a map, the map also filters duplicates (cannot add twice the same key).

But the rows for the table are reserved before filtering, this explains why there is an empty row at the end of the table:
![Screenshot_20201217_104121](https://user-images.githubusercontent.com/5566160/102470543-6cb27f80-4054-11eb-8017-12396929bad2.png)

Because of this empty row the software crashes when clicking the `>>` to put this topic in the output file.

I have just moved the row resizing just after the filtering so that we are sure the number of rows corresponds to the number of elements in the `connections_ordered` vector.